### PR TITLE
Removes Good Friday from Federal Reserve holidays enum

### DIFF
--- a/lib/holidays/federal_reserve.rb
+++ b/lib/holidays/federal_reserve.rb
@@ -18,7 +18,6 @@ module Holidays
 
     def self.holidays_by_month
       {
-              0 => [{:function => lambda { |year| Holidays.easter(year)-2 }, :function_id => "easter(year)-2", :name => "Good Friday", :regions => [:federal_reserve]}],
       1 => [{:mday => 1, :observed => lambda { |date| Holidays.to_monday_if_sunday(date) }, :observed_id => "to_monday_if_sunday", :name => "New Year's Day", :regions => [:federal_reserve]},
             {:wday => 1, :week => 3, :name => "Birthday of Martin Luther King, Jr", :regions => [:federal_reserve]},
             {:function => lambda { |year| Holidays.us_inauguration_day(year) }, :function_id => "us_inauguration_day(year)", :name => "Inauguration Day", :regions => [:federal_reserve]}],


### PR DESCRIPTION
**Why:**
- Tenants are unable to schedule rent payments for Friday, March 30th. That date is Good Friday, which we're including as a Fed national holiday when it is not.

**Solution:**
- Remove Good Friday from Federal Reserve holiday config object.